### PR TITLE
update _BATCH_SIZE value

### DIFF
--- a/kubernetes/sidecar/proxy-profile.yaml
+++ b/kubernetes/sidecar/proxy-profile.yaml
@@ -11,7 +11,7 @@ spec:
   config:
     config.tpl: |
       pipy({
-          _BATCH_SIZE: 5,
+          _BATCH_SIZE: 2000,
           _BATCH_TIMEOUT: 5000,
           _CONTENT_TYPES: {
               '': true,


### PR DESCRIPTION
If this value is too small, the CPU load of pipy will be increased. You can adjust this parameter according to the performance of the individual host.